### PR TITLE
MCOL-306

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -233,6 +233,7 @@ storage/mroonga/vendor/groonga/src/groonga-benchmark
 storage/mroonga/vendor/groonga/src/suggest/groonga-suggest-create-dataset
 storage/mroonga/mysql-test/mroonga/storage/r/information_schema_plugins.result
 storage/mroonga/mysql-test/mroonga/storage/r/variable_version.result
+mariadb-columnstore-engine/
 # C and C++
 
 # Compiled Object files

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "mariadb-columnstore-engine"]
-	path = mariadb-columnstore-engine
-	url = https://github.com/mariadb-corporation/mariadb-columnstore-engine.git
-	branch = develop

--- a/README.md
+++ b/README.md
@@ -88,11 +88,12 @@ To build the current development branch
   * git clone https://github.com/mariadb-corporation/mariadb-columnstore-server.git 
   * cd mariadb-columnstore-server
   * git checkout develop        # switch to develop code
-  * git submodule update --init # pull in engine code
   * cmake . -DCMAKE_INSTALL_PREFIX=/usr/local/mariadb/columnstore/mysql
   * make -jN                    # N is the number of concurrent build processes and should likely be the number of cores available
   * sudo make install
+  * git clone https://github.com/mariadb-corporation/mariadb-columnstore-engine.git
   * cd mariadb-columnstore-engine
+  * git checkout develop
   * cmake . 
   * make -jN                    # same as above with respect to concurrent processes
   * sudo make install


### PR DESCRIPTION
Removes the mariadb-columnstore-engine submodule and updates the README
