### PR TITLE
MCOL-441 Fix segfault on SP error

### DIFF
--- a/sql/sql_select.cc
+++ b/sql/sql_select.cc
@@ -3609,8 +3609,7 @@ mysql_select(THD *thd, Item ***rref_pointer_array,
   {
     for (global_list = thd->lex->query_tables; global_list; global_list = global_list->next_global)
     {
-      if (!global_list->index_hints)
-        global_list->index_hints= new (thd->mem_root) List<Index_hint>();
+      global_list->index_hints= new (thd->mem_root) List<Index_hint>();
 
       global_list->index_hints->push_front(new (thd->mem_root)
                                            Index_hint(INDEX_HINT_USE,


### PR DESCRIPTION
A stored procedure error could lead to an attempt to access index_hints
after they have already been freed. This patch creates a new index_hints
on every ColumnStore query, because we don't need the index_hints
supplied by the lexer for ColumnStore anyway.