### PR TITLE
MCOL-652 Fix certain derived table cases

### DIFF
--- a/sql/sql_select.cc
+++ b/sql/sql_select.cc
@@ -3615,13 +3615,18 @@ mysql_select(THD *thd, Item ***rref_pointer_array,
   {
     for (global_list = thd->lex->query_tables; global_list; global_list = global_list->next_global)
     {
-      global_list->index_hints= new (thd->mem_root) List<Index_hint>();
+      // MCOL-652 - doing this with derived tables can cause bad things to happen
+      if (!global_list->derived)
+      {
+        global_list->index_hints= new (thd->mem_root) List<Index_hint>();
 
-      global_list->index_hints->push_front(new (thd->mem_root)
+        global_list->index_hints->push_front(new (thd->mem_root)
                                            Index_hint(INDEX_HINT_USE,
                                                       INDEX_HINT_MASK_JOIN,
                                                       NULL,
                                                       0), thd->mem_root);
+
+      }
     }
   }
 


### PR DESCRIPTION
Don't add USE INDEX() to derived tables. Regression due to MCOL-424.