### PR TITLE
MCOL-650 Prep stmt + CALL use vtable

### DIFF
--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -9685,86 +9685,6 @@ int idb_vtable_process(THD* thd, ulonglong old_optimizer_switch, Statement* stat
 				{
 					thd->infinidb_vtable.isInsertSelect = true;
 				}
-				else if (thd->lex->sql_command == SQLCOM_EXECUTE || thd->get_command() == COM_STMT_EXECUTE)
-				{
-					//@Bug 2703 Added the support of prepared statement with and without variables binding
-					//Save the query in case we need set it back
-					char *query = thd->query();
-					uint32 query_length = thd->query_length();
-					Prepared_statement *stmt = (Prepared_statement*)statement;
-					LEX *lex= thd->lex;
-					String expanded_query ;
-
-					if (!stmt)
-					{
-						//Bind variable and parse statement
-						LEX_STRING *name= &lex->prepared_stmt_name;
-						stmt= (Prepared_statement*) thd->stmt_map.find_by_name(name);
-					}
-
-					if ( stmt )
-					{
-						if ( stmt->param_count == lex->prepared_stmt_params.elements )
-						{
-							stmt->set_parameters(&expanded_query, NULL, NULL);
-						}
-						// replace ? with values
-						std::string tmp_query = std::string (stmt->query());
-						std::string::size_type p1 = tmp_query.find("?");
-						std::string replaceStr;
-						Item_param **begin= stmt->param_array;
-						while (p1 != std::string::npos)
-						{
-							Item_param *param= *begin;
-							if (param->state == Item_param::NO_VALUE)
-							{
-								replaceStr = "NULL";
-							}
-							else
-							{
-								String val, *str;
-								str = param->val_str(&val);
-								if ( param->item_type == Item::STRING_ITEM )
-									replaceStr = "'" + std::string(str->c_ptr()) + "'";
-								else
-									replaceStr = std::string(str->c_ptr());
-							}
-
-							tmp_query.replace( p1, 1, replaceStr);
-							begin++;
-							p1 = tmp_query.find("?");
-						}
-						alloc_query(thd, tmp_query.c_str(), tmp_query.length());
-
-						// pre parse statement to tell DML statement from select
-						lex_start(thd);
-						thd->reset_for_next_command();
-
-						Parser_state parser_state;
-						parser_state.init(thd, thd->query(), thd->query_length());
-						parse_sql(thd, &parser_state, NULL, true);
-
-						if (thd->lex->sql_command != SQLCOM_SELECT)
-						{
-							INFINIDB_execute = false;
-							if ( thd->lex->sql_command != SQLCOM_DELETE )
-							{
-								// set original query back
-								thd->set_query(query, query_length);
-							}
-							//Set to table mode for DML statement
-							thd->infinidb_vtable.vtable_state = THD::INFINIDB_DISABLE_VTABLE;
-							thd->infinidb_vtable.autoswitch = false;
-							isSqlExecute = true;
-						}
-					}
-					else
-					{
-						thd->infinidb_vtable.isInfiniDBDML = false;
-						thd->infinidb_vtable.hasInfiniDBTable = false;
-						DBUG_RETURN(-1);
-					}
-				}
 				else if (thd->lex->sql_command == SQLCOM_CALL)
 				{
 					thd->infinidb_vtable.original_query.free();
@@ -9870,6 +9790,86 @@ int idb_vtable_process(THD* thd, ulonglong old_optimizer_switch, Statement* stat
 							break;
 						}
 						break;
+					}
+				}
+        else if (thd->lex->sql_command == SQLCOM_EXECUTE || thd->get_command() == COM_STMT_EXECUTE)
+				{
+					//@Bug 2703 Added the support of prepared statement with and without variables binding
+					//Save the query in case we need set it back
+					char *query = thd->query();
+					uint32 query_length = thd->query_length();
+					Prepared_statement *stmt = (Prepared_statement*)statement;
+					LEX *lex= thd->lex;
+					String expanded_query ;
+
+					if (!stmt)
+					{
+						//Bind variable and parse statement
+						LEX_STRING *name= &lex->prepared_stmt_name;
+						stmt= (Prepared_statement*) thd->stmt_map.find_by_name(name);
+					}
+
+					if ( stmt )
+					{
+						if ( stmt->param_count == lex->prepared_stmt_params.elements )
+						{
+							stmt->set_parameters(&expanded_query, NULL, NULL);
+						}
+						// replace ? with values
+						std::string tmp_query = std::string (stmt->query());
+						std::string::size_type p1 = tmp_query.find("?");
+						std::string replaceStr;
+						Item_param **begin= stmt->param_array;
+						while (p1 != std::string::npos)
+						{
+							Item_param *param= *begin;
+							if (param->state == Item_param::NO_VALUE)
+							{
+								replaceStr = "NULL";
+							}
+							else
+							{
+								String val, *str;
+								str = param->val_str(&val);
+								if ( param->item_type == Item::STRING_ITEM )
+									replaceStr = "'" + std::string(str->c_ptr()) + "'";
+								else
+									replaceStr = std::string(str->c_ptr());
+							}
+
+							tmp_query.replace( p1, 1, replaceStr);
+							begin++;
+							p1 = tmp_query.find("?");
+						}
+						alloc_query(thd, tmp_query.c_str(), tmp_query.length());
+
+						// pre parse statement to tell DML statement from select
+						lex_start(thd);
+						thd->reset_for_next_command();
+
+						Parser_state parser_state;
+						parser_state.init(thd, thd->query(), thd->query_length());
+						parse_sql(thd, &parser_state, NULL, true);
+
+						if (thd->lex->sql_command != SQLCOM_SELECT)
+						{
+							INFINIDB_execute = false;
+							if ( thd->lex->sql_command != SQLCOM_DELETE )
+							{
+								// set original query back
+								thd->set_query(query, query_length);
+							}
+							//Set to table mode for DML statement
+							thd->infinidb_vtable.vtable_state = THD::INFINIDB_DISABLE_VTABLE;
+							thd->infinidb_vtable.autoswitch = false;
+							isSqlExecute = true;
+						}
+					}
+					else
+					{
+						thd->infinidb_vtable.isInfiniDBDML = false;
+						thd->infinidb_vtable.hasInfiniDBTable = false;
+						DBUG_RETURN(-1);
 					}
 				}
 

--- a/sql/sql_prepare.cc
+++ b/sql/sql_prepare.cc
@@ -4216,7 +4216,7 @@ bool Prepared_statement::execute(String *expanded_query, bool open_cursor)
     }
   }
 
-  if (bHasInfiniDB && thd->get_command() == COM_STMT_EXECUTE)
+  if ((bHasInfiniDB && thd->get_command() == COM_STMT_EXECUTE) || (thd->lex->sql_command == SQLCOM_CALL))
   {
     // @bug5298. disable re-prepare observer for infinidb query
     thd->m_reprepare_observer = NULL;


### PR DESCRIPTION
With SQLCOM_CALL (stored procedures) prepared statements were falling
through to vtable disable straight away. This changes the behaviour to
the same as normal queries, that is to inspect the first query of a
stored procedure and execute using vtable if it is ColumnStore.

The change rearranges sql_prepare as we don't want to fall into
thd->get_command() == COM_STMT_EXECUTE before checking for SQLCOM_CALL.