### PR TITLE
MCOL-650 Prep stmt + CALL use vtable

### DIFF
--- a/sql/sql_prepare.cc
+++ b/sql/sql_prepare.cc
@@ -4216,7 +4216,7 @@ bool Prepared_statement::execute(String *expanded_query, bool open_cursor)
     }
   }
 
-  if (bHasInfiniDB && thd->get_command() == COM_STMT_EXECUTE)
+  if ((bHasInfiniDB && thd->get_command() == COM_STMT_EXECUTE) || (thd->lex->sql_command == SQLCOM_CALL))
   {
     // @bug5298. disable re-prepare observer for infinidb query
     thd->m_reprepare_observer = NULL;


### PR DESCRIPTION
With SQLCOM_CALL (stored procedures) prepared statements were falling
through to vtable disable straight away. This changes the behaviour to
the same as normal queries, that is to inspect the first query of a
stored procedure and execute using vtable if it is ColumnStore.

The change rearranges sql_prepare as we don't want to fall into
thd->get_command() == COM_STMT_EXECUTE before checking for SQLCOM_CALL.