### PR TITLE
MCOL-693 Fix non-string SP parameters

### DIFF
--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -10337,7 +10337,7 @@ int idb_vtable_process(THD* thd, ulonglong old_optimizer_switch, Statement* stat
 								  continue;
 
 								std::string arg_name = spvar->name.str;
-								std::string arg_val = arg_item->name;
+								std::string arg_val(arg_item->val_str()->c_ptr(), arg_item->val_str()->length());
 								uint len = spvar->name.length;
 								if (arg_item->type() ==  Item::STRING_ITEM)
 									arg_val = "'" + arg_val + "'";


### PR DESCRIPTION
arg_item->name is a NULL ptr for non-strings in 10.x. Instead use
val_str() which will do the conversion for us.