### PR TITLE
MCOL-736 Fix implicit commit on SELECT

### DIFF
--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -10109,7 +10109,7 @@ int idb_vtable_process(THD* thd, ulonglong old_optimizer_switch, Statement* stat
 
 					// phase 4. drop vtable -- Now done first
 					thd->infinidb_vtable.drop_vtable_query.free();
-					thd->infinidb_vtable.drop_vtable_query.append(STRING_WITH_LEN("drop table if exists "));
+					thd->infinidb_vtable.drop_vtable_query.append(STRING_WITH_LEN("drop temporary table if exists "));
 					thd->infinidb_vtable.drop_vtable_query.append(vtable_name.c_str(), vtable_name.length());
 					thd->infinidb_vtable.drop_vtable_query.append(STRING_WITH_LEN(" restrict"));
 


### PR DESCRIPTION
A select query would implicit commit a transaction due to the "DROP
TABLE" in our vtable processing. Since this is a temporary table this
patch switches to "DROP TEMPORARY TABLE" which does not trigger an
implicit commit.