### PR TITLE
MCOL-800 Allow prepared stmt I_S with vtable

### DIFF
--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -10449,7 +10449,7 @@ int idb_vtable_process(THD* thd, ulonglong old_optimizer_switch, Statement* stat
                             parser_state.init(thd, thd->query(), thd->query_length());
                             parse_sql(thd, &parser_state, NULL, true);
 
-                            if (thd->lex->sql_command != SQLCOM_SELECT)
+                            if ((thd->lex->sql_command != SQLCOM_SELECT) && (thd->lex->sql_command != SQLCOM_INSERT_SELECT))
                             {
                                 INFINIDB_execute = false;
                                 if ( thd->lex->sql_command != SQLCOM_DELETE )
@@ -10462,6 +10462,10 @@ int idb_vtable_process(THD* thd, ulonglong old_optimizer_switch, Statement* stat
                                 thd->infinidb_vtable.autoswitch = false;
                                 isSqlExecute = true;
                             }
+                            else if (thd->lex->sql_command == SQLCOM_INSERT_SELECT)
+				            {
+            					thd->infinidb_vtable.isInsertSelect = true;
+				            }
                         }
 					}
 					else


### PR DESCRIPTION
An I_S within a prepared statement was falling through to disable
vtable. This patch allows it to use vtable as if it was a normal query.