### PR TITLE
MCOL-829 Allow stored procs to use I_S

### DIFF
--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -9796,7 +9796,11 @@ int idb_vtable_process(THD* thd, ulonglong old_optimizer_switch, Statement* stat
 							parse_sql(thd, &parser_state, NULL, true);
 						}
 
-						if (thd->lex->sql_command != SQLCOM_SELECT /*&&  thd->lex->sql_command != SQLCOM_END*/)
+        				if (thd->lex->sql_command == SQLCOM_INSERT_SELECT)
+		        		{
+				        	thd->infinidb_vtable.isInsertSelect = true;
+        				}
+                        else if (thd->lex->sql_command != SQLCOM_SELECT /*&&  thd->lex->sql_command != SQLCOM_END*/)
 						{
 							INFINIDB_execute = false;
 							// set original query back


### PR DESCRIPTION
This patch allows INSERT...SELECTS to work inside stored procedures with
vtable mode enabled.