### PR TITLE
MCOL-954 Init vtable state

### DIFF
--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -2976,6 +2976,7 @@ public:
 	INFINIDB_VTABLE() : cal_conn_info(NULL) {init();}
 	void init()
 	{
+        vtable_state = INFINIDB_INIT_CONNECT;
 		autoswitch = false;
 		has_order_by = false;
 		duplicate_field_name = false;


### PR DESCRIPTION
vtable state isn't initialized for the slave thread which means when
create view is replicated we can hit an assert due to a bad vtable_state
when acquiring a lock.