### PR TITLE
MCOL-954 Init vtable state

### DIFF
--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -2822,7 +2822,8 @@ public:
 	bool isInfiniDBDML; // default false
   	bool hasInfiniDBTable; // default false
 	bool isNewQuery;
-	INFINIDB_VTABLE() : autoswitch(false),
+	INFINIDB_VTABLE() : vtable_state(INFINIDB_INIT_CONNECT),
+                        autoswitch(false),
 		                has_order_by(false),
 		                mysql_optimizer_off(false),
 		                duplicate_field_name(false),


### PR DESCRIPTION
vtable state isn't initialized for the slave thread which means when
create view is replicated we can hit an assert due to a bad vtable_state
when acquiring a lock.